### PR TITLE
INFRA-28632 Empty commit (no-op) to force new image build with latest awscli version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [1.2.0_mintel.0.2.0] - 2023-01-17
+### Added
+- Add changelog
+
+### Changed
+- No-op to pull `awscli` version `2.9.15`


### PR DESCRIPTION
`awscli` version is pulled at build time (see https://github.com/mintel/build-harness-extensions/pull/121), so this is a no-op change to force a new build.

Also added a changelog so this seems a little less trivial...